### PR TITLE
add: `bulkAdd()` call to external library import override method

### DIFF
--- a/src/app/renderer/src/lib/db/types.ts
+++ b/src/app/renderer/src/lib/db/types.ts
@@ -181,6 +181,7 @@ export class ExternalAccount extends Data {
                 return await db.library.bulkAdd(entries);
 
             case ImportMethod.Overwrite:
+                await db.library.bulkAdd(entries);
                 return await db.library.bulkPut(entries);
 
             case ImportMethod.Latest:


### PR DESCRIPTION
Closes #38 